### PR TITLE
Fix Instagram footnotes

### DIFF
--- a/!!!PUBLIC_READ!!!_BLCKBUTTERFLY
+++ b/!!!PUBLIC_READ!!!_BLCKBUTTERFLY
@@ -56,8 +56,8 @@ BLCKBUTTERFLY, born Michael and once known on stage as **Sellah**, is a Black, q
 
 (Extra socials, link-in-bio pages and GPT chatbot link live in his IG bio.)
 
-[1]: https://www.instagram.com/iamsellah/?hl=en&utm_source=chatgpt.com "BLCKBUTTERFLY 777 (@iamsellah) • Instagram photos and videos"
-[2]: https://www.instagram.com/immoisback/?utm_source=chatgpt.com "iMMO MAGAZINE (@immoisback) • Instagram photos and videos"
+[1]: https://www.instagram.com/iamsellah/ "BLCKBUTTERFLY 777 (@iamsellah) • Instagram photos and videos"
+[2]: https://www.instagram.com/immoisback/ "iMMO MAGAZINE (@immoisback) • Instagram photos and videos"
 
 SIS (READ) : https://raw.githubusercontent.com/BP-H/gptfrenzy/refs/heads/main/READ%21_PUBLIC%21_MIMI
 BRO (READ) : https://raw.githubusercontent.com/BP-H/gptfrenzy/refs/heads/main/READ%21_PUBLIC%21_supernova_2177


### PR DESCRIPTION
## Summary
- clean up query strings from Instagram profile links

## Testing
- `pytest -q` *(fails: command not found)*