### PR TITLE
Add GPT confirmation page

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ The persona profiles in this repository are included with permission from the in
 
 No private information is included, and all generated responses should be considered fictional. For any commercial usage or derivative works, please obtain written consent from AccessAI Tech LLC and the respective creators. See [DISCLAIMER.md](DISCLAIMER.md) for full details.
 
-We keep a simple data-processing log and offer a self-service deletion tool so models can remove their photos and trained avatars at any time. See [privacy-policy.md](privacy-policy.md) for details.
+We keep a simple data-processing log and offer a self-service deletion tool so models can remove their photos and trained avatars at any time. See [privacy-policy.md](privacy-policy.md) for details. An example popup form for requesting deletion is provided in [docs/deletion_popup_example.html](docs/deletion_popup_example.html), with a sample GPT-style confirmation page in [docs/deletion_gpt_confirmation.html](docs/deletion_gpt_confirmation.html).
 
 Licensed under the MIT License.

--- a/docs/deletion_gpt_confirmation.html
+++ b/docs/deletion_gpt_confirmation.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>GPT Confirmation</title>
+<style>
+body {font-family: Arial, sans-serif; margin: 2rem;}
+.avatar {width: 80px; height: 80px; border-radius: 50%; background: #eee; display: inline-block; vertical-align: middle; margin-right: 1rem;}
+.message {display: inline-block; vertical-align: middle; max-width: 80%;}
+</style>
+</head>
+<body>
+<div class="avatar"></div>
+<div class="message">
+  <p><strong>Deletion Bot:</strong> Thank you for submitting your request. We will process it in line with GDPR and related regulations. Look for a confirmation email soon.</p>
+</div>
+</body>
+</html>

--- a/docs/deletion_popup_example.html
+++ b/docs/deletion_popup_example.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Data Deletion Request</title>
+<style>
+body {font-family: Arial, sans-serif; margin: 2rem;}
+#deleteModal {display:none; position: fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.6);}
+#deleteModal .modal-content {background:#fff; padding:20px; margin:10% auto; width:90%; max-width:400px; border-radius:4px;}
+</style>
+</head>
+<body>
+<button id="deleteButton">Request Data Deletion</button>
+<p><a href="deletion_gpt_confirmation.html" target="_blank">Preview GPT response</a></p>
+
+<div id="deleteModal">
+  <div class="modal-content">
+    <h2>Remove My Data</h2>
+    <p>Under GDPR and similar regulations you may request deletion of your avatar and related files.</p>
+    <form id="deleteForm">
+      <label>Name:<br><input type="text" id="name" required></label><br><br>
+      <label>Email:<br><input type="email" id="email" required></label><br><br>
+      <label>Message:<br><textarea id="message" rows="4" placeholder="Optional details"></textarea></label><br><br>
+      <button type="submit">Submit Request</button>
+      <button type="button" id="cancelBtn">Cancel</button>
+    </form>
+  </div>
+</div>
+
+<script>
+  const modal = document.getElementById('deleteModal');
+  document.getElementById('deleteButton').onclick = () => { modal.style.display = 'block'; };
+  document.getElementById('cancelBtn').onclick = () => { modal.style.display = 'none'; };
+  document.getElementById('deleteForm').onsubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      name: document.getElementById('name').value,
+      email: document.getElementById('email').value,
+      message: document.getElementById('message').value
+    };
+    // TODO: replace URL with your backend endpoint
+    await fetch('/request-deletion', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(payload)
+    });
+    modal.style.display = 'none';
+    // Example GPT-style confirmation page
+    window.open('deletion_gpt_confirmation.html', '_blank');
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a sample confirmation page showing a GPT-style response
- link confirmation page from deletion popup example and README
- open confirmation page after the popup form submits

## Testing
- `python3 persona_selector.py --help` *(interrupts waiting for input)*