### PR TITLE
Add GDPR deletion link references

### DIFF
--- a/!!!ATTENTION_READ_ALL!!!_COMPANY_GPT_INSTRUCTIONS.txt
+++ b/!!!ATTENTION_READ_ALL!!!_COMPANY_GPT_INSTRUCTIONS.txt
@@ -22,6 +22,7 @@
 - About: https://www.accessaitech.com/about
 - Contact: https://www.accessaitech.com
 - LinkedIn: https://www.linkedin.com/company/accessai-tech-llc/
+- Deletion Request Form: https://github.com/BP-H/gptfrenzy/blob/main/docs/deletion_popup_example.html
 
 # Chat With Our Team
 - **Mimi GPT**: https://chatgpt.com/g/g-681c5724c660819196e26b14870c3726-mimi

--- a/!!!ATTENTION_READ_ALL!!!_MIMI_GPT_INSTRUCTIONS.txt
+++ b/!!!ATTENTION_READ_ALL!!!_MIMI_GPT_INSTRUCTIONS.txt
@@ -51,6 +51,8 @@ ASK THEM WHAT BROUGHT THEM HERE AND BEHAVE TO IMPRESS THEM ACCORDINGLY, TRY TO G
     Instagram: @access\_ai, @studiomimi\_style, @mimi\_fashionai, @supernova\_2177
     (These IG profiles show our personal art as well as company updates—posts there aren’t always official statements.)
    LinkedIn company page.
+   For data removal requests provide this link:
+   https://github.com/BP-H/gptfrenzy/blob/main/docs/deletion_popup_example.html
    • If referencing outside press, confirm it cites AccessAI Tech; otherwise summarize without linking.
 
 8. **Response formatting.**

--- a/!!!ATTENTION_READ_ALL!!!_supernova_GPT_INSTRUCTIONS.txt
+++ b/!!!ATTENTION_READ_ALL!!!_supernova_GPT_INSTRUCTIONS.txt
@@ -16,8 +16,9 @@ Only search online at these addresses and provide these links after knowing the 
 * https://www.accessaitech.com/models
 * https://www.accessaitech.com/about
 * https://www.accessaitech.com/apply
-* https://www.accessaitech.com/groups
-* Company LinkedIn: https://www.linkedin.com/company/accessai-tech-llc/
+ * https://www.accessaitech.com/groups
+ * Company LinkedIn: https://www.linkedin.com/company/accessai-tech-llc/
+ * Data Removal: https://github.com/BP-H/gptfrenzy/blob/main/docs/deletion_popup_example.html
 
 # Tone & Diction
 * **Casual & Encouraging** – Use informal language, "lol," "haha," etc.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ The persona profiles in this repository are included with permission from the in
 
 No private information is included, and all generated responses should be considered fictional. For any commercial usage or derivative works, please obtain written consent from AccessAI Tech LLC and the respective creators. See [DISCLAIMER.md](DISCLAIMER.md) for full details.
 
-We keep a simple data-processing log and offer a self-service deletion tool so models can remove their photos and trained avatars at any time. See [privacy-policy.md](privacy-policy.md) for details. An example popup form for requesting deletion is provided in [docs/deletion_popup_example.html](docs/deletion_popup_example.html).
+We keep a simple data-processing log and offer a self-service deletion tool so models can remove their photos and trained avatars at any time. See [privacy-policy.md](privacy-policy.md) for details. An example popup form for requesting deletion is provided in [docs/deletion_popup_example.html](docs/deletion_popup_example.html) with a matching demo server at [docs/deletion_server_example.py](docs/deletion_server_example.py).
 
 Licensed under the MIT License.

--- a/docs/deletion_popup_example.html
+++ b/docs/deletion_popup_example.html
@@ -37,8 +37,9 @@ body {font-family: Arial, sans-serif; margin: 2rem;}
       email: document.getElementById('email').value,
       message: document.getElementById('message').value
     };
-    // TODO: replace URL with your backend endpoint
-    await fetch('/request-deletion', {
+    // Example: send the request to a simple Flask server
+    // (see docs/deletion_server_example.py)
+    await fetch('http://localhost:5000/request-deletion', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(payload)

--- a/docs/deletion_server_example.py
+++ b/docs/deletion_server_example.py
@@ -1,0 +1,14 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route('/request-deletion', methods=['POST'])
+def request_deletion():
+    data = request.get_json(force=True)
+    # In a real implementation you would verify the request
+    # and remove the associated data from your systems.
+    print('Received deletion request:', data)
+    return jsonify({'status': 'received'})
+
+if __name__ == '__main__':
+    app.run(port=5000)


### PR DESCRIPTION
## Summary
- reference deletion popup example and demo server in README
- show how to POST deletion requests in the HTML example
- add a simple Flask server for deletion requests
- update all GPT instruction files with a deletion form link except BLCKBUTTERFLY

## Testing
- `python3 persona_selector.py --help` *(shows menu and waits for input, then interrupted)*