### PR TITLE
Replace Codex references with ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ Each instruction file has an associated deep knowledge file. Load both at the st
 
 ## Quick Start (Don't Skip): Merge Instruction and Knowledge Files
 
-Before loading a persona into ChatGPT Codex, combine its instruction file with the corresponding deep knowledge file:
+Before loading a persona into ChatGPT, combine its instruction file with the corresponding deep knowledge file:
 
 1. Open the desired `*_GPT_INSTRUCTIONS.txt` in a text editor.
 2. Append the entire contents of the matching `*_DEEP_KNOWLEDGE_*.txt` directly below the instructions.
 3. Remove extra blank lines or repeated sections so the merged file stays concise.
-4. Make sure the final text remains under **50&nbsp;KB** for smooth Codex uploads.
+4. Make sure the final text remains under **50&nbsp;KB** for smooth uploads.
 5. Save the combined text as a new file ready to upload.
 
 For a detailed walkthrough, see [docs/codex_integration.md](docs/codex_integration.md).
 
-## Using These Prompts with ChatGPT Codex
-1. Open ChatGPT Codex and start a new conversation.
+## Using These Prompts with ChatGPT
+1. Open ChatGPT and start a new conversation.
 2. Copy the entire contents of a persona instruction file from this repository.
 3. Paste it as the first message to set the desired persona. (Include any linked deep knowledge file text if required.)
 4. Continue the conversation normally.
@@ -54,14 +54,14 @@ For a detailed walkthrough, see [docs/codex_integration.md](docs/codex_integrati
 * This assistant is experimental and carries no legal liabilities.
 * Persona: masculine, gay, and sparkly...
 ```
-Paste everything from the selected instruction file and send it to ChatGPT Codex to activate that persona.
+Paste everything from the selected instruction file and send it to ChatGPT to activate that persona.
 
 ## Persona Selector
 
 To make choosing a persona easier, run `persona_selector.py` from this
 repository. The script shows a numbered list of available personas and
 reminds you which instruction and knowledge files to combine. Note that
-ChatGPT Codex only supports **one persona at a time**. Start a new
+ChatGPT only supports **one persona at a time**. Start a new
 conversation whenever you want to switch personas.
 ## Play the Mini Game
 

--- a/docs/codex_integration.md
+++ b/docs/codex_integration.md
@@ -1,15 +1,15 @@
-# Loading Instruction Files into ChatGPT Codex
+# Loading Instruction Files into ChatGPT
 
-The new ChatGPT Codex interface lets you upload a small instruction file that guides the model. Follow these steps:
+The ChatGPT custom instructions interface lets you upload a small instruction file that guides the model. Follow these steps:
 
 1. **Create your instruction file** – Save your custom instructions in a text-based format such as Markdown or plain text. Keep the file brief to ensure quick loading.
-2. **Open ChatGPT Codex** – In the ChatGPT side panel, select the Codex option to open the upload interface.
+2. **Open ChatGPT** – In the ChatGPT side panel, open the custom instructions interface.
 3. **Upload your file** – Use the file picker to select the instruction file. The contents will appear in the editor for review.
 4. **Start chatting** – Once the file is loaded, send a message to begin. The instructions will guide the assistant's behavior.
 
-## Sample Codex JSON
+## Sample JSON Format
 
-Below is an example message payload in the new Codex format. The `system` message contains the uploaded instructions.
+Below is an example message payload for the custom instructions format. The `system` message contains the uploaded instructions.
 ```json
 {
   "messages": [
@@ -27,15 +27,15 @@ Below is an example message payload in the new Codex format. The `system` messag
 
 ## Merging Persona Prompts with Deep Knowledge
 
-Some personas in this repository have a corresponding `DEEP_KNOWLEDGE` file that expands on the tone, vocabulary, and backstory. Before uploading to Codex, merge the persona prompt with its knowledge file so the assistant has the full context.
+Some personas in this repository have a corresponding `DEEP_KNOWLEDGE` file that expands on the tone, vocabulary, and backstory. Before uploading to ChatGPT, merge the persona prompt with its knowledge file so the assistant has the full context.
 
 1. Open the desired `GPT_INSTRUCTIONS.txt` file.
 2. Append the entire contents of the matching `DEEP_KNOWLEDGE_*.txt` file beneath the instructions.
-3. Save the combined text as a single file and upload that file to Codex.
+3. Save the combined text as a single file and upload that file to ChatGPT.
 
 ### Sample Combined Message
 
-Below is an abbreviated example showing how a merged instruction set might appear inside a Codex payload.
+Below is an abbreviated example showing how a merged instruction set might appear inside a ChatGPT payload.
 
 ```json
 {
@@ -52,8 +52,8 @@ Below is an abbreviated example showing how a merged instruction set might appea
 }
 ```
 
-### Tips for Staying Within Codex Upload Limits
+### Tips for Staying Within Upload Limits
 
-- Codex accepts relatively small files (roughly under 50&nbsp;KB). Keep your merged file concise so it loads quickly.
+- ChatGPT accepts relatively small files (roughly under 50&nbsp;KB). Keep your merged file concise so it loads quickly.
 - Remove unnecessary blank lines, comments, or duplicate sections before uploading.
 - Focus on the most important instructions and knowledge to stay well within the limit.


### PR DESCRIPTION
## Summary
- update README to call it **ChatGPT** instead of ChatGPT Codex
- revise docs/codex_integration.md to reflect the current ChatGPT instructions interface

## Testing
- `grep -R "Codex" README.md docs`